### PR TITLE
Increased minSdkVersion from 15 to 16

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "25.0.2"
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 16
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
In build.gradle
  Increased minSdkVersion from 15 to 16 in order to address:
    "Manifest merger failed : uses-sdk:minSdkVersion 15 cannot be smaller"
  Error when building using gradle for android.