### PR TITLE
Invoke handler explicitly for the first CallEvent

### DIFF
--- a/iOS/RCTCallDetection/RCTCallDetection/CallDetectionManager.m
+++ b/iOS/RCTCallDetection/RCTCallDetection/CallDetectionManager.m
@@ -74,6 +74,8 @@ RCT_EXPORT_METHOD(stopListener) {
         [self sendEventWithName:@"PhoneCallStateUpdate"
                                                      body:[eventNameMap objectForKey: call.callState]];
     }];
+    [self sendEventWithName:@"PhoneCallStateUpdate"
+                                                     body:[eventNameMap objectForKey: call.callState]];
 }
 
 @end


### PR DESCRIPTION
This is a BUGFIX

The first call event was getting lost in the ObjC layer (not delivered to the JS layer).