### PR TITLE
Fixed bug

### DIFF
--- a/android/src/main/java/com/pritesh/calldetection/CallDetectionManagerModule.java
+++ b/android/src/main/java/com/pritesh/calldetection/CallDetectionManagerModule.java
@@ -116,17 +116,15 @@ public class CallDetectionManagerModule
         switch (state) {
             //Hangup
             case TelephonyManager.CALL_STATE_IDLE:
-                if(wasAppInRinging == true ) {
-                    if(wasAppInOffHook == true) {
-                        jsModule.callStateUpdated("Disconnected", null);
-
-                    } else {
-                        jsModule.callStateUpdated("Missed", null);
-                    }
+                if(wasAppInOffHook == true) { // if there was an ongoing call and the call state switches to idle, the call must have gotten disconnected
+                    jsModule.callStateUpdated("Disconnected", null);
+                } else if(wasAppInRinging == true) { // if the phone was ringing but there was no actual ongoing call, it must have gotten missed
+                    jsModule.callStateUpdated("Missed", null);
                 }
+
+                //reset device state
                 wasAppInRinging = false;
                 wasAppInOffHook = false;
-                // Device call state: No activity.
                 break;
             //Outgoing
             case TelephonyManager.CALL_STATE_OFFHOOK:


### PR DESCRIPTION
Fixed the bug, where the library wouldn't emit a "Disconnected" event in case the user did call someone and then ended the call on Android.

Fix description:
"Disconnected" event only requieres an active call to have happened - not that there was a call ringing.

Before: wasAppInRinging && wasAppInOffHook => Disconnected
Now: wasAppInOffHook => Disconnected