### PR TITLE
Fix for false Android "Disconnected" event when app returns from background

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,6 @@ Example project can be used to test out the package. In the example project upda
   }
 ```
 
-### Caveat 
-Since For android, there is no native support to detect call being disconnected, the callback with "Disconnected" event will be called only when the app comes in foreground.
-
 ### How to run an example
 
 1. Install `node` and `watchman`

--- a/android/src/main/java/com/pritesh/calldetection/CallDetectionManagerModule.java
+++ b/android/src/main/java/com/pritesh/calldetection/CallDetectionManagerModule.java
@@ -83,10 +83,7 @@ public class CallDetectionManagerModule
 
     @Override
     public void onActivityResumed(Activity activity) {
-        if (wasAppInOffHook && jsModule != null) {
-            wasAppInOffHook = false;
-            jsModule.callStateUpdated("Disconnected", null);
-        }
+
     }
 
     @Override

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-call-detection",
-  "version": "1.6.4",
+  "version": "1.7.0",
   "description": "Get different phone call states for iOS and Android along with incoming phone number(just for android)",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Resolves #17 

It appears that the removed code was initially put in place to counter a previous/anticipated Android bug that prevented the app from receiving the call state update events when the app was running in the background. I have found that removing the manual "Disconnect" event when the app returns from the background allows for the app to receive the proper disconnect signal when the event actually occurs.