### PR TITLE
Updated dependencies configuration from 'compile' to 'api' to remove unsupported warnings.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.facebook.react:react-native:+'
+    api fileTree(dir: 'libs', include: ['*.jar'])
+    api 'com.android.support:appcompat-v7:23.0.1'
+    api 'com.facebook.react:react-native:+'
 }

--- a/android/src/main/java/com/pritesh/calldetection/CallDetectionManagerModule.java
+++ b/android/src/main/java/com/pritesh/calldetection/CallDetectionManagerModule.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
 import android.telephony.PhoneStateListener;
 import android.telephony.TelephonyManager;
 import android.util.Log;
@@ -60,7 +59,6 @@ public class CallDetectionManagerModule
      * @return a map of constants this module exports to JS. Supports JSON types.
      */
     public
-    @Nullable
     Map<String, Object> getConstants() {
         Map<String, Object> map = new HashMap<String, Object>();
         map.put("Incoming", "Incoming");


### PR DESCRIPTION
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html.