### PR TITLE
Fixed linking/build error on Android. Removed constructor dependency on CallDetectionManager

### DIFF
--- a/CallDetectionExample/android/.idea/misc.xml
+++ b/CallDetectionExample/android/.idea/misc.xml
@@ -4,15 +4,15 @@
     <entry_points version="2.0" />
   </component>
   <component name="NullableNotNullManager">
-    <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
-    <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
+    <option name="myDefaultNullable" value="androidx.annotation.Nullable" />
+    <option name="myDefaultNotNull" value="androidx.annotation.NonNull" />
     <option name="myNullables">
       <value>
         <list size="4">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
-          <item index="3" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
+          <item index="3" class="java.lang.String" itemvalue="androidx.annotation.Nullable" />
         </list>
       </value>
     </option>
@@ -22,7 +22,7 @@
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
-          <item index="3" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
+          <item index="3" class="java.lang.String" itemvalue="androidx.annotation.NonNull" />
         </list>
       </value>
     </option>

--- a/README.md
+++ b/README.md
@@ -12,47 +12,8 @@ yarn add react-native-call-detection
 
 ```
 
-Link the current package to your react native project
-
-```shell
-react-native link react-native-call-detection
-
-```
-
 ### For Android:-
-Just Verify that the following changes are present in the corresponding files
-
--  In `MainApplication.java`
-
-``` diff
-+ import com.pritesh.calldetection.CallDetectionManager;
-	@Override
-    protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
-          new MainReactPackage(),
-+     new CallDetectionManager(MainApplication.this)
-      );
-    }
-  };
-```
-- In `android/settings.gradle`:
-
-```diff
-...
-include ':app'
-+ include ':react-native-call-detection'
-+ project(':react-native-call-detection').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-call-detection/android')
-``` 
-	
-- In `android/app/build.gradle`:
-
-```diff
-dependencies {
-    ...
-    compile "com.facebook.react:react-native:+"  // From node_modules
-+   compile project(':react-native-call-detection')
-}
-```
+Autolinking should work without manual changes
 
 ## Usage
 There are different hooks that you may get depending on the platform. Since for android you could also request the package to provide you with phone number of the caller, you will have to provide the necessary request message and the corresponding error callback. The package will request for `READ_PHONE_STATE` permission in android.
@@ -63,39 +24,40 @@ Its really easy to setup the package. Have a look at the following code snippet
 import CallDetectorManager from 'react-native-call-detection'
 
 startListenerTapped() {
-	this.callDetector = new CallDetectorManager((event)=> {
+	this.callDetector = new CallDetectorManager((event, phoneNumber)=> {
 	// For iOS event will be either "Connected",
 	// "Disconnected","Dialing" and "Incoming"
-	
+
 	// For Android event will be either "Offhook",
 	// "Disconnected", "Incoming" or "Missed"
-	
+	// phoneNumber should store caller/called number
+
 
 	if (event === 'Disconnected') {
 	// Do something call got disconnected
-	} 
+	}
 	else if (event === 'Connected') {
 	// Do something call got connected
 	// This clause will only be executed for iOS
-	} 
+	}
 	else if (event === 'Incoming') {
 	// Do something call got incoming
 	}
 	else if (event === 'Dialing') {
 	// Do something call got dialing
 	// This clause will only be executed for iOS
-	} 
+	}
 	else if (event === 'Offhook') {
-	//Device call state: Off-hook. 
+	//Device call state: Off-hook.
 	// At least one call exists that is dialing,
-	// active, or on hold, 
+	// active, or on hold,
 	// and no calls are ringing or waiting.
 	// This clause will only be executed for Android
 	}
 	else if (event === 'Missed') {
     	// Do something call got missed
     	// This clause will only be executed for Android
-    }
+  }
 },
 false, // if you want to read the phone number of the incoming call [ANDROID], otherwise false
 ()=>{}, // callback if your permission got denied [ANDROID] [only if you want to read incoming number] default: console.error
@@ -133,7 +95,7 @@ Example project can be used to test out the package. In the example project upda
 	```
 	brew install node
 	brew install watchman
-	 
+
 	```
 
 2. `yarn`
@@ -154,7 +116,7 @@ Example project can be used to test out the package. In the example project upda
 5. Once you have done all the above steps, navigate to `CallDetectionExample` folder and run `yarn` or `npm install`, it will fetch all the dependencies in the `node_modules` folder.
 
 6. Run the packager
-	`npm start` 
+	`npm start`
 
 7. Update the mobile number of your friend in [`HomeComponent.js`](CallDetectionExample/src/HomeComponent.js)
 
@@ -167,17 +129,17 @@ Example project can be used to test out the package. In the example project upda
         console.log(err)
       });
   	 }
-  	
+
 	```
 
 7. To run the example on iOS from terminal type
 	`react-native run-ios` (This will open the simulator, since simulator doesnt have the support for calling I will advice you to connect your iOS device and the follow the below procedure for running the app through xcode)
-	
+
 	or you can also run the app from xcode, for that, open `/CallDectionExample/ios/CallDetectionExample.xcodeproj` in xcode and run on the device.
-	
+
 8. To run the example on android, connect any android device to your mac then follow the below steps
 	1. Navigate to `android` folder(./CallDectionExample/android/) folder and then run `adb reverse tcp:8081 tcp:8081`
 	2. Navigate back to example directory(CallDectionExample) and then run
 	`react-native run-android`
-	
-For any problems and doubt raise an issue.	
+
+For any problems and doubt raise an issue.

--- a/android/src/androidTest/java/com/pritesh/calldetection/ExampleInstrumentedTest.java
+++ b/android/src/androidTest/java/com/pritesh/calldetection/ExampleInstrumentedTest.java
@@ -1,8 +1,8 @@
 package com.pritesh.calldetection;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/android/src/main/java/com/pritesh/calldetection/CallDetectionManager.java
+++ b/android/src/main/java/com/pritesh/calldetection/CallDetectionManager.java
@@ -5,7 +5,6 @@ import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
-import android.app.Application;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -14,19 +13,11 @@ import java.util.Arrays;
 
 public class CallDetectionManager implements ReactPackage {
 
-    private Application applicationInstance;
-
-    public CallDetectionManager(Application applicationInstance) {
-        super();
-        this.applicationInstance = applicationInstance;
-    }
-
     @Override
     public List<NativeModule> createNativeModules(
             ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
         CallDetectionManagerModule callDetectionModule = new CallDetectionManagerModule(reactContext);
-        applicationInstance.registerActivityLifecycleCallbacks(callDetectionModule);
         modules.add(callDetectionModule);
 
         return modules;


### PR DESCRIPTION
Android fixes:

* Fixed linking/build error on Android. Removed CallDetectionManager constructor dependency on "android.app.Application".
  * RN-0.60.3. Threw errors on compilation process as CallDetectionManager constructor needed a parameter and none was being passed.
  * Application instance is taken from currentActivity on CallDetectionManagerModule when startListener is called

* PhoneNumber now sent on all events.

* Modified README as Android autolinking should work without manual changes