### PR TITLE
Fix/request permission android Call-Log.

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
   package="com.pritesh.calldetection">
 
   <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+  <uses-permission android:name="android.permission.READ_CALL_LOG" />
 
   <application
     android:allowBackup="true"

--- a/index.js
+++ b/index.js
@@ -17,11 +17,11 @@ const NativeCallDetectorAndroid = NativeModules.CallDetectionManagerAndroid
 var CallStateUpdateActionModule = require('./CallStateUpdateActionModule')
 BatchedBridge.registerCallableModule('CallStateUpdateActionModule', CallStateUpdateActionModule)
 
-const requestPermissionsAndroid = async (permissionMessage) => {
-    return await PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.READ_PHONE_STATE)
-      .then(async (gotPermission) => gotPermission
+const requestPermissionsAndroid = (permissionMessage) => {
+    return PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.READ_PHONE_STATE)
+      .then((gotPermission) => gotPermission
           ? true
-          : await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.READ_PHONE_STATE, permissionMessage)
+          : PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.READ_PHONE_STATE, permissionMessage)
               .then((result) => result === PermissionsAndroid.RESULTS.GRANTED)
         )
 }

--- a/index.js
+++ b/index.js
@@ -19,20 +19,15 @@ BatchedBridge.registerCallableModule('CallStateUpdateActionModule', CallStateUpd
 
 // https://stackoverflow.com/questions/13154445/how-to-get-phone-number-from-an-incoming-call : Amjad Alwareh's answer.
 const requestPermissionsAndroid = (permissionMessage) => {
-  return Promise.all([
-    PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.READ_PHONE_STATE)
-      .then((gotPermission) => gotPermission
-        ? true
-        : PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.READ_PHONE_STATE, permissionMessage)
-          .then((result) => result === PermissionsAndroid.RESULTS.GRANTED)
-      ),
-    PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.READ_CALL_LOG)
-      .then((gotPermission) => gotPermission
-        ? true
-        : PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.READ_CALL_LOG, permissionMessage)
-          .then((result) => result === PermissionsAndroid.RESULTS.GRANTED)
-      ),
-  ])
+  const requiredPermission = Platform.constants.Release >= 9
+    ? PermissionsAndroid.PERMISSIONS.READ_CALL_LOG
+    : PermissionsAndroid.PERMISSIONS.READ_PHONE_STATE
+  return PermissionsAndroid.check(requiredPermission)
+    .then((gotPermission) => gotPermission
+      ? true
+      : PermissionsAndroid.request(requiredPermission, permissionMessage)
+        .then((result) => result === PermissionsAndroid.RESULTS.GRANTED)
+    )
 }
 
 class CallDetectorManager {
@@ -58,7 +53,7 @@ class CallDetectorManager {
               const releaseNumber = Platform.constants.Release
 
               // for all android version: need read phone state
-              // for version >= 9: also need read call log 
+              // for version >= 9: also need read call log
               if (!permissionGrantedPhoneState || (!permissionGrantedCallLog && releaseNumber >= 9 )) {
                 permissionDeniedCallback(permissionDenied)
               }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var CallStateUpdateActionModule = require('./CallStateUpdateActionModule')
 BatchedBridge.registerCallableModule('CallStateUpdateActionModule', CallStateUpdateActionModule)
 
 const requestPermissionsAndroid = async (permissionMessage) => {
-      await PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.READ_PHONE_STATE)
+    return await PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.READ_PHONE_STATE)
       .then(async (gotPermission) => gotPermission
           ? true
           : await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.READ_PHONE_STATE, permissionMessage)

--- a/index.js
+++ b/index.js
@@ -49,12 +49,8 @@ class CallDetectorManager {
         if (readPhoneNumberAndroid) {
 
           requestPermissionsAndroid(permissionMessage)
-            .then(([permissionGrantedPhoneState, permissionGrantedCallLog]) => {
-              const releaseNumber = Platform.constants.Release
-
-              // for all android version: need read phone state
-              // for version >= 9: also need read call log
-              if (!permissionGrantedPhoneState || (!permissionGrantedCallLog && releaseNumber >= 9 )) {
+            .then((permissionGrantedRedState) => {
+              if (!permissionGrantedRedState) {
                 permissionDeniedCallback(permissionDenied)
               }
             })

--- a/index.js
+++ b/index.js
@@ -49,8 +49,8 @@ class CallDetectorManager {
         if (readPhoneNumberAndroid) {
 
           requestPermissionsAndroid(permissionMessage)
-            .then((permissionGrantedRedState) => {
-              if (!permissionGrantedRedState) {
+            .then((permissionGrantedReadState) => {
+              if (!permissionGrantedReadState) {
                 permissionDeniedCallback(permissionDenied)
               }
             })


### PR DESCRIPTION
Hopefully resolving [https://github.com/priteshrnandgaonkar/react-native-call-detection/issues/76](android empty phone number)

I had the same issue:
![image](https://user-images.githubusercontent.com/26758925/95909776-e9bf3100-0d53-11eb-966b-db5c7e0b682d.png)

After checking https://stackoverflow.com/questions/13154445/how-to-get-phone-number-from-an-incoming-call - Amjad Alwareh's answer, I have learned that we need READ_CALL_LOG. 

My android version is 11, so I made this patch and it worked as expected.
![image](https://user-images.githubusercontent.com/26758925/95910002-402c6f80-0d54-11eb-8366-9ad30a0404e9.png)

Let me know your thoughts! Thanks for making this great library. 