### PR TITLE
Bugfix: incorrect events

### DIFF
--- a/iOS/RCTCallDetection/RCTCallDetection/CallDetectionManager.m
+++ b/iOS/RCTCallDetection/RCTCallDetection/CallDetectionManager.m
@@ -52,15 +52,12 @@ RCT_EXPORT_METHOD(stopListener) {
 - (void)callObserver:(CXCallObserver *)callObserver callChanged:(CXCall *)call {
     if (call.hasEnded == true) {
       [self sendEventWithName:@"PhoneCallStateUpdate" body:@"Disconnected"];
-    }
-    if (call.isOutgoing == true && call.hasConnected == false && call.hasEnded == false) {
-      [self sendEventWithName:@"PhoneCallStateUpdate" body:@"Dialing"];
-    }
-    if (call.isOutgoing == false && call.hasConnected == false) {
-      [self sendEventWithName:@"PhoneCallStateUpdate" body:@"Incoming"];
-    }
-    if (call.hasEnded == false && call.hasConnected == true) {
+    } else if (call.hasConnected == true) {
       [self sendEventWithName:@"PhoneCallStateUpdate" body:@"Connected"];
+    } else if (call.isOutgoing == true) {
+      [self sendEventWithName:@"PhoneCallStateUpdate" body:@"Dialing"];
+    } else {
+      [self sendEventWithName:@"PhoneCallStateUpdate" body:@"Incoming"];
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-call-detection",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Get different phone call states for iOS and Android along with incoming phone number(just for android)",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This PR try to fix the incorrect logic in `callObserver` delegate for iOS code.

Issue we found:
- For reject / missed call action: we will get two events: `diconnected` and `incoming` which the second incoming is incorrect. For each event we should only receive one notification.

Changes:
- Reorganised the logic in `callObserver` delegate method.
- Test on iOS 14 and all looking good.