### PR TITLE
React Native Android import fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,21 @@ yarn add react-native-call-detection
 
 ```
 
-### For Android:-
-Autolinking should work without manual changes
+### For Android:
+
+In `android/app/src/main/java/.../MainApplication.java`:
+
+```java
+import com.pritesh.calldetection.CallDetectionReactPackage; // Add this import line
+//...
+
+private static List<ReactPackage> getPackages() {
+    return Arrays.<ReactPackage>asList(
+        new MainReactPackage(),
+        new CallDetectionReactPackage() // Add this line
+    );
+}
+```
 
 ## Usage
 There are different hooks that you may get depending on the platform. Since for android you could also request the package to provide you with phone number of the caller, you will have to provide the necessary request message and the corresponding error callback. The package will request for `READ_PHONE_STATE` permission in android.

--- a/android/src/main/java/com/pritesh/calldetection/CallDetectionReactPackage.java
+++ b/android/src/main/java/com/pritesh/calldetection/CallDetectionReactPackage.java
@@ -11,6 +11,10 @@ import java.util.List;
 
 public class CallDetectionReactPackage implements ReactPackage {
 
+    public CallDetectionReactPackage() {
+
+    }
+
     // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();

--- a/android/src/main/java/com/pritesh/calldetection/CallDetectionReactPackage.java
+++ b/android/src/main/java/com/pritesh/calldetection/CallDetectionReactPackage.java
@@ -1,0 +1,31 @@
+package com.pritesh.calldetection;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class CallDetectionReactPackage implements ReactPackage {
+
+    // Deprecated RN 0.47
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(
+            ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+        modules.add(new CallDetectionManagerModule(reactContext));
+        return modules;
+    }
+}


### PR DESCRIPTION
Issue: Android devices were not able to detect phone calls.

README is updated showing how to setup it on android devices from now on. iOS devices are not affected.