### PR TITLE
Expo SDK 44 no longer supports the conditional imports

### DIFF
--- a/iOS/RCTCallDetection/RCTCallDetection/CallDetectionManager.h
+++ b/iOS/RCTCallDetection/RCTCallDetection/CallDetectionManager.h
@@ -11,13 +11,8 @@
 //#import <React/RCTBridgeModule.h>
 //#import <React/RCTEventEmitter.h>
 
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#import "RCTEventEmitter.h"
-#else
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
-#endif
 #import <Foundation/Foundation.h>
 #import <CallKit/CallKit.h>
 


### PR DESCRIPTION
See the following:

- https://github.com/expo/expo/pull/15626
- https://github.com/birkir/react-native-sfsymbols/pull/22
- https://github.com/LinusU/react-native-get-random-values/pull/33

Root report:

- https://github.com/expo/expo/issues/15649